### PR TITLE
use env python instead of /usr/bin/python

### DIFF
--- a/modules/weather.py
+++ b/modules/weather.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
 


### PR DESCRIPTION
Use env python so that script functions in a 'venv' python environment.

My system does not have the latest python so i use 'venv' to run it.  This causes the weather module to fail. 

If the shebang is usr/bin/env python instead, the proper python is picked up.

ie: http://www.cyberciti.biz/tips/finding-bash-perl-python-portably-using-env.html
