### PR TITLE
Documentation Typo Fix

### DIFF
--- a/docs/source/ubuntu.rst
+++ b/docs/source/ubuntu.rst
@@ -49,7 +49,7 @@ Start xvfb, fluxbox and Skype::
 
 Start VNC server::
 
-    sevabot/scripts/start-vcn.sh start
+    sevabot/scripts/start-vnc.sh start
 
 On your local computer start vnviewer (vncviewer is for Linux, for other OS
 use any VNC capable remote desktop viewing software)


### PR DESCRIPTION
Hey,

Just some small correction to the documentation. 
start-vcn -> start-vnc
