### PR TITLE
Adding a check for a valid JSON response from the weather API in !weather

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog for Sevabot
 1.2.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Adding a check for a valid JSON response from the weather API in !weather [mpdavis] 
 
 
 1.2.4 (2013-03-17)

--- a/modules/weather.py
+++ b/modules/weather.py
@@ -27,7 +27,10 @@ def call_weather_api(location):
 
     request = urllib.urlopen(url % location)
 
-    payload = json.loads(request.read())
+    try:
+        payload = json.loads(request.read())
+    except ValueError:
+        sys.exit('Error: No data')
 
     if 'cod' in payload and payload['cod'] == '200':
         if 'list' in payload:


### PR DESCRIPTION
In the event that the openweathermap.org API doesn't return a valid JSON response, the weather script will throw a ValueError exception.

![Error Image](http://content.screencast.com/users/mikedavis.webfilings/folders/Jing/media/0997ed5e-f57b-4728-a82d-2ea95ec46913/00000047.png)

This adds a check to the json load and exits in the event that the load call throws a ValueError.

![Fixed Image](http://content.screencast.com/users/mikedavis.webfilings/folders/Jing/media/20fb453f-5f87-40a7-8cc8-4ffc0dbdd9bb/00000049.png)
