### PR TITLE
Fixes msg referenced before assignment

### DIFF
--- a/sevabot/frontend/api.py
+++ b/sevabot/frontend/api.py
@@ -168,6 +168,7 @@ class JenkinsNotifier(SendMessage):
     """
 
     def compose(self):
+        msg = None
 
         try:
             payload = json.loads(request.form.keys()[0])


### PR DESCRIPTION
Should fix this error coming up in the logs when receiving Jenkins notifications with the status "COMPLETED":

```
sevabot.frontend.api - ERROR - local variable 'msg' referenced before assignment
Traceback (most recent call last):
  File "/home/skype/sevabot/sevabot/frontend/api.py", line 55, in dispatch_request
    msg = self.compose()
  File "/home/skype/sevabot/sevabot/frontend/api.py", line 189, in compose
    return msg
```
