### PR TITLE
Update for Jenkins notification plugin. 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,10 @@
 Changelog for Sevabot
 -------------------------
 
-1.2.5 (unreleased)
+1.2.5 (2013-07-29)
 ------------------
 
-- Nothing changed yet.
+- Updated Jenkins notification webhook to work with v1.5 of the Jenkins notification plugin [justnom]
 
 
 1.2.4 (2013-03-17)

--- a/docs/source/jenkins.rst
+++ b/docs/source/jenkins.rst
@@ -21,6 +21,8 @@ Install the plugin as directed in the above wiki link.
 
 In Jenkins, for each build you want to send notifications for, under the 'Job Notifications' section, click 'Add Endpoint'.
 
+Select 'JSON' and 'HTTP' in the ''Format' and 'Protocol' drop-down menus, respectively.
+
 Enter your sevabot jenkins-notification endpoint, for example:
 http://sevabot.example.com:5000/jenkins-notifier/{your-channel-id}/{your-shared-secret}/
 

--- a/sevabot/frontend/api.py
+++ b/sevabot/frontend/api.py
@@ -189,7 +189,7 @@ class JenkinsNotifier(SendMessage):
         msg = None
 
         try:
-            payload = json.loads(request.form.keys()[0])
+            payload = json.loads(request.data)
         except IndexError:
             logger.error("Jenkins did not post a valid HTTP POST payload. Check the logs for further info.")
             logger.error(request.form.items())

--- a/sevabot/frontend/api.py
+++ b/sevabot/frontend/api.py
@@ -187,14 +187,11 @@ class JenkinsNotifier(SendMessage):
 
     def compose(self):
         msg = None
+        payload = request.json
 
-        try:
-            payload = json.loads(request.data)
-        except IndexError:
+        if payload is None:
             logger.error("Jenkins did not post a valid HTTP POST payload. Check the logs for further info.")
-            logger.error(request.form.items())
             return "Jenkins bad notification: Could not read HTTP POST data"
-
         # Filter out completed status, lots of unneeded noise
         if payload['build']['phase'] != 'COMPLETED':
             if payload['build']['status'] == 'SUCCESS':


### PR DESCRIPTION
Update for v1.5 of the [Jenkins notification plugin](https://wiki.jenkins-ci.org/display/JENKINS/Notification+Plugin). Notification JSON object now sent in body by the plugin with the header `Content-type: application/json`.
