### PR TITLE
build status STARTED causes error

### DIFF
--- a/sevabot/frontend/api.py
+++ b/sevabot/frontend/api.py
@@ -193,10 +193,10 @@ class JenkinsNotifier(SendMessage):
             logger.error("Jenkins did not post a valid HTTP POST payload. Check the logs for further info.")
             return "Jenkins bad notification: Could not read HTTP POST data"
         # Filter out completed status, lots of unneeded noise
-        if payload['build']['phase'] != 'COMPLETED':
+        if payload['build']['phase'] != 'COMPLETED' && payload['build']['phase'] != 'STARTED':
             if payload['build'].get('status') == 'SUCCESS':
                 msg = u'Project: %s build #%d %s Status: %s - (sun) - %s\n' % (payload['name'], payload['build']['number'], payload['build']['phase'], payload['build']['status'], payload['build']['full_url'])
-            elif payload['build']['status'] == 'FAILURE':
+            elif payload['build'].get('status') == 'FAILURE':
                 msg = u'Project: %s build #%d %s Status: %s - (rain) - %s\n' % (payload['name'], payload['build']['number'], payload['build']['phase'], payload['build']['status'], payload['build']['full_url'])
             else:
                 msg = u'Project: %s build #%d %s Status: %s - - %s\n' % (payload['name'], payload['build']['number'], payload['build']['phase'], payload['build']['status'], payload['build']['full_url'])

--- a/sevabot/frontend/api.py
+++ b/sevabot/frontend/api.py
@@ -193,7 +193,7 @@ class JenkinsNotifier(SendMessage):
             logger.error("Jenkins did not post a valid HTTP POST payload. Check the logs for further info.")
             return "Jenkins bad notification: Could not read HTTP POST data"
         # Filter out completed status, lots of unneeded noise
-        if payload['build']['phase'] != 'COMPLETED' && payload['build']['phase'] != 'STARTED':
+        if payload['build']['phase'] != 'COMPLETED' and payload['build']['phase'] != 'STARTED':
             if payload['build'].get('status') == 'SUCCESS':
                 msg = u'Project: %s build #%d %s Status: %s - (sun) - %s\n' % (payload['name'], payload['build']['number'], payload['build']['phase'], payload['build']['status'], payload['build']['full_url'])
             elif payload['build'].get('status') == 'FAILURE':


### PR DESCRIPTION
there are 2 bugs, one is that phase == 'STARTED' should plausibly be handled the same way as phase == 'STARTED', the other is that line #199 causes a KeyError when that happens, and should probably be using dict.get as line 196 does
